### PR TITLE
Adjust cheatmenu filters for nomads units

### DIFF
--- a/nomadhook/lua/ui/dialogs/createunitfilters.lua
+++ b/nomadhook/lua/ui/dialogs/createunitfilters.lua
@@ -1,0 +1,30 @@
+for _,filter in Filters do
+    -- Add the nomads faction filters
+    if filter.key == 'faction' then
+        local nomads = {
+                title = 'Nomads',
+                key = 'nomads',
+                sortFunc = function(unitID)
+                    if string.sub(unitID, 2, 2) == 'n' then
+                        return true
+                    end
+                    return false
+                end,
+            }
+        table.insert(filter.choices, 5, nomads) -- after 'seraphim', but before 'operation'
+    end
+    
+    -- Take into account that nomads land units use 'u' instead of 'l' in their unitID
+    if filter.key == 'type' then
+        for _,typeChoice in filter.choices do
+            if typeChoice.key == 'land' then
+                typeChoice.sortFunc = function(unitID)
+                        if string.sub(unitID, 3, 3) == 'l' or string.sub(unitID, 3, 3) == 'u' then
+                            return true
+                        end
+                        return false
+                    end
+            end
+        end
+    end
+end


### PR DESCRIPTION
Just added the nomads filter option and made the 'land' filter also keep nomads land units.
For some reason nomads land units all have 'u' instead of 'l' in their unitIDs, even the civilian truck...